### PR TITLE
preview txt

### DIFF
--- a/data/system.lua
+++ b/data/system.lua
@@ -1,8 +1,8 @@
 -- system state
-norns.state.script = 'tests/_txt.lua'
+norns.state.script = 'grid_seek.lua'
 norns.state.out = '64'
-norns.state.monitor = '7'
+norns.state.monitor = '21.0'
 norns.state.monitor_mode = '0'
-norns.state.input_left = '48.0'
-norns.state.input_right = '48.0'
-norns.state.hp = '50'
+norns.state.input_left = '48'
+norns.state.input_right = '48'
+norns.state.hp = '50.0'

--- a/lua/16sliders.lua
+++ b/lua/16sliders.lua
@@ -1,4 +1,11 @@
---16sliders
+-- 16sliders
+--
+-- step sequencing a mono sine
+--
+-- enc 2 = select step
+-- enc 3 = tune step
+-- key 2 = random walk
+-- key 3 = mutate
 
 sliders = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 edit = 1

--- a/lua/draw.lua
+++ b/lua/draw.lua
@@ -1,4 +1,7 @@
--- drawing
+-- draw demo
+--
+-- code shows all of the screen
+-- drawing functions
 
 -- specify dsp engine to load:
 engine.name = 'TestSine'

--- a/lua/flin.lua
+++ b/lua/flin.lua
@@ -1,4 +1,5 @@
--- @txt cyclic poly-rhythm music box
+-- cyclic poly-rhythm music box
+
 engine.name = 'PolySub'
 
 local GRID_HEIGHT = 8

--- a/lua/grid_poly.lua
+++ b/lua/grid_poly.lua
@@ -1,7 +1,8 @@
--- @txt subtractive polysynth
+-- subtractive polysynth
 -- controlled by grid
 -- knob 2 selects param
 -- knob 3 changes selected param
+
 local tab = require 'tabutil'
 
 engine.name = 'PolySub'

--- a/lua/grid_seek.lua
+++ b/lua/grid_seek.lua
@@ -1,4 +1,10 @@
--- @txt test grid sequencer
+-- test grid sequencer
+--
+-- knob 1 = tempo
+-- knob 2 = filter
+-- knob 3 = decay
+-- key 2 = random sequence
+-- key 3 = random pulsewidth
 
 engine.name = 'PolyPerc'
 
@@ -88,9 +94,9 @@ enc = function(n, delta)
 end
 
 key = function(n)
-  if n == 2 then
+  if n == 2 and z == 1 then
     for i=1, 16 do steps[i] = math.floor(math.random()*8) end
-  elseif n == 3 then
+  elseif n == 3 and z == 1 then
     engine.pw(math.random()*1)
   end
 end

--- a/lua/ptest.lua
+++ b/lua/ptest.lua
@@ -1,3 +1,6 @@
+-- param test
+--
+
 engine.name = 'TestSine'
 
 init = function()

--- a/lua/softrepeat.lua
+++ b/lua/softrepeat.lua
@@ -1,5 +1,12 @@
--- key 2 start stop
--- key 3 hold clears records until release
+-- SOFTREPEAT (looper)
+--
+-- K1 held = load file
+-- K2 start stop
+-- K3 hold clears records
+--          until release
+-- E1 vol
+-- E2 loop len
+-- E3 speed
 
 fs = require "fileselect"
 

--- a/lua/template.lua
+++ b/lua/template.lua
@@ -1,8 +1,21 @@
--- @name template
--- @version 1.0.3
--- @author tehn
--- @url http://monomengine.org
--- @txt a very basic example
+-- TEMPLATE 1.0.0
+-- http://monome.org
+-- 
+-- a code example showing the
+-- basic functions and how to
+-- use them.
+--
+-- see additional documentation
+-- at...
+--
+-- ////////
+-- ////
+-- //////
+-- /////////////
+-- //
+-- ///////
+-- ///
+-- /
 
 -- specify dsp engine to load:
 engine.name = 'TestSine'


### PR DESCRIPTION
updated the script preview method.

got rid of metadata --@name all together. now the preview just reads all of the double-dash comments from the beginning of the file up until a non-comment line and uses that as the txt preview. scrolling also works.

no automatic line breaks or formatting. screen is ~28 chars wide.

(requires norns PR)