### PR TITLE
add metro stress test, CA class

### DIFF
--- a/data/lib/emb/elca.lua
+++ b/data/lib/emb/elca.lua
@@ -1,0 +1,106 @@
+--- elementary cellular automata
+-- @module elca
+-- @alias CA
+
+local CA = {}
+
+CA.__index = CA
+
+CA.numStates = 128
+CA.BOUND_LOW = 0
+CA.BOUND_HIGH = 1
+CA.BOUND_WRAP = 2
+
+-- constructor
+function CA.new()
+   local ca = setmetatable({}, CA)
+   
+    ca.state = {}
+    for i=1,CA.numStates do
+       ca.state[i] = 0
+    end
+    
+    ca.bound_mode_l = BOUND_LOW
+    ca.bound_mode_r = BOUND_LOW
+    ca.bound_l = 1
+    ca.bound_r = 128
+    
+    ca.rule = 34
+    ca.offset = 0
+    return ca
+end 
+
+-- update all state
+function CA:update() 
+   local newState = {}
+   for i=1,CA.numStates do
+      local l, c, r = self:neighbors(i)
+--      print (l, c, r)
+      local code = CA.code(l, c, r)
+      if (self.rule & (1 << code)) > 0 then newState[i] = 1
+      else newState[i] = 0 end
+   end
+   self.state = newState
+end
+
+--- helper: return three values to use for neighbor code
+--- @return tuple of left, right, center
+function CA:neighbors(i)
+   local l
+   local r
+
+   if i <= self.bound_l then
+      if self.bound_mode_l == CA.BOUND_LOW then l = 0
+      elseif self.bound_mode_l == CA.BOUND_HIGH then l = 1 
+      else l = self.state[self.bound_r] end
+   else
+      l = self.state[i-1]
+   end
+   
+   -- right neighbor
+   if i >= CA.numStates then
+      if self.bound_mode_r == CA.BOUND_LOW then r = 0
+      elseif self.bound_mode_r == CA.BOUND_HIGH then r = 1 
+      else r = self.state[self.bound_l] end
+   else
+      r = self.state[i+1]
+   end
+   
+--   print("get_neighbors ", i, ":", l, self.state[i], r)
+   return l, self.state[i], r
+end
+
+--- get binary code for value given cell and neighbors
+function CA.code(l, c, r)
+   local n = 0
+   if l > 0 then n = n | 4 end
+   if c > 0 then n = n | 2 end   
+   if r > 0 then n = n | 1 end
+   return n
+end
+
+--- return 8 cells at current offset
+--- @return table with 8 binary values
+function CA:window(n)
+   if n == nil then n = CA.numStates end
+   local w = {}
+   for i=1,n do
+      w[i] = self.state[i + self.offset]
+   end
+   return w
+end 
+
+-- change current state at index,
+--- and update the rule to that which would have produced the new state
+function CA:set_rule_by_state(val, l, r, c)
+   if self.oldState[i] ~= val then
+      self.oldState[i] = val
+      local code = CA.code(l, r, c)
+      if val then rule = rule | 2
+      else rule = rule & 5 end
+   end
+end
+
+-- TODO: maybe setter methods that clamp stuff
+
+return CA

--- a/lua/emb/elca-test.lua
+++ b/lua/emb/elca-test.lua
@@ -1,0 +1,59 @@
+local elca = require 'emb.elca'
+--local grid = require 'grid'
+
+local ca = elca.new()
+local m = metro[1]
+
+ca.state[1] = 1
+ca.state[5] = 1
+ca.state[8] = 1
+ca.rule = 110
+
+ca.bound_mode_l = elca.BOUND_WRAP
+ca.bound_mode_r = elca.BOUND_WRAP
+ca.bound_l = 1
+ca.bound_r = 8
+
+
+local history = {}
+for i=1, 16 do
+   local col = {}
+   for j=1,8 do
+      col[j] = 0
+   end
+   table.insert(history, col)
+end
+
+function gridredraw()
+   if g == nil then return end
+   for i=1, 16 do
+      local col = history[i]
+      for j=1,8 do
+	 g:led(i, j, col[j])
+      end
+   end
+end
+
+m.callback = function(stage)
+   ca:update()
+   local col = ca:window(8)
+   history[17] = col
+   table.remove(history, 1)
+
+   gridredraw()
+   
+   local str = ""
+   for i=1,8 do      
+      if col[i] > 0 then str = str .. "0" else str = str .. "." end
+   end
+   print(str)end
+
+m.time = 0.125
+
+
+engine.name = 'TestSine'
+init = function()
+   
+   print("grid: ", g)
+   m:start()
+end

--- a/lua/tests/metro-stress.lua
+++ b/lua/tests/metro-stress.lua
@@ -1,0 +1,44 @@
+engine.name = 'TestSine'
+
+local math = require 'math'
+
+init = function()
+
+   engine.amp(0.25)
+
+   t = {}
+   
+   for i=1,10 do
+      local m = metro[i]
+      m.time = 0.01 * (i+1)
+      m.callback = function(stage)
+	 engine.hz((stage % 10)* 100 + 100)
+      end      
+      m:start()
+      t[i] = true
+   end
+
+   function toggle(i) 
+      if t[i] then
+	 t[i] = false
+	 metro[i]:stop()
+      else
+	 t[i] = true
+	 local count = math.random(-1, 3)
+	 print("new count: " .. count)
+	 metro[i]:start(nil, count)
+	 --metro[i]:start()
+      end
+   end
+
+   for i = 11,20 do
+      local m = metro[i]
+      m.time = 0.125 * (i-9)      
+      m.callback = function(stage)
+	 print ("toggling " .. i-10)
+	 toggle(i-10)
+      end   
+      m:start()	       
+   end
+   
+end


### PR DESCRIPTION
as threatened, have added a basic elementary cellular automata sequencer class.

one motivation is to look at grid refresh and also lua garbage collection.

one thing i notice is that after running for a long time, refresh gets choppy. cpu usage stays low. relaunching script helps, replugging grid doesn't... so seems ilke a GC issue. (every update includes inserting an array into a table and removing another array. should try copying all data instead, using a shadow buffer, &c.)

anyway, pretty lights.

oh also there is a script designed to push metro system pretty hard.