### PR TITLE
fix output mix level setting

### DIFF
--- a/scripts/jah/hello_ack.lua
+++ b/scripts/jah/hello_ack.lua
@@ -198,7 +198,7 @@ end
 
 enc = function(n, delta)
   if n == 1 then
-    norns.audio.adjust_output_level(delta)
+    mix:delta("output", delta)
     return
   elseif n == 2 then
     local new_selection

--- a/scripts/jah/step.lua
+++ b/scripts/jah/step.lua
@@ -290,7 +290,7 @@ end
 -- encoder function
 enc = function(n, delta)
   if n == 1 then
-    norns.audio.adjust_output_level(delta)
+    mix:delta("output", delta)
   elseif n == 2 then
     params:delta("tempo", delta)
   elseif n == 3 then

--- a/scripts/jah/why.lua
+++ b/scripts/jah/why.lua
@@ -10,7 +10,7 @@ end
 
 enc = function(n, delta)
   if n == 1 then
-    norns.audio.adjust_output_level(delta)
+    mix:delta("output", delta)
   end
 end
 

--- a/scripts/study/poly.lua
+++ b/scripts/study/poly.lua
@@ -171,7 +171,7 @@ end
 
 enc = function(n,delta)
 	if n == 1 then
-		norns.audio.adjust_output_level(delta) 
+		mix:delta("output", delta)
 	elseif n==2 then
 		cur_param_id = util.clamp(cur_param_id + delta,1,tab.count(pparams))
 	elseif n==3 then

--- a/scripts/tehn/earthsea.lua
+++ b/scripts/tehn/earthsea.lua
@@ -204,7 +204,7 @@ end
 
 function enc(n,delta)
   if n == 1 then
-    norns.audio.adjust_output_level(delta)
+    mix:delta("output", delta)
   end
 end
 


### PR DESCRIPTION
calls to `norns.audio.adjust_output_level(delta)` were failing like this:

```
lua: 
/home/we/norns/lua/audio.lua:93: attempt to perform arithmetic on a nil value (field 'out')
stack traceback:
/home/we/norns/lua/audio.lua:93: in function 'audio.adjust_output_level'
/home/we/dust/scripts/tehn/earthsea.lua:275: in function 'encoders.callback'
/home/we/norns/lua/encoders.lua:53: in function 'encoders.process'
```

migrating to `mix:delta("output", delta)` fixes it (cheers @artfwo!)

see: https://github.com/catfact/norns/pull/317

/cc @tehn @artfwo 


