### PR TITLE
remove gratuitous metro free

### DIFF
--- a/scripts/artfwo/flin.lua
+++ b/scripts/artfwo/flin.lua
@@ -252,7 +252,3 @@ function redraw()
 
   screen.update()
 end
-
-function cleanup()
-  metro.free_all()
-end


### PR DESCRIPTION
looking at `script.lua` it looks like this cleanup is unnecessary?

https://github.com/monome/norns/blob/90b16dfa3a4d2114e448a4fb4558f1b8687680dd/lua/script.lua#L24-L25

/cc @artfwo 