### PR TITLE
fix polyperc oscillator

### DIFF
--- a/lib/sc/Engine_PolyPerc.sc
+++ b/lib/sc/Engine_PolyPerc.sc
@@ -14,7 +14,7 @@ Engine_PolyPerc : CroneEngine {
 	alloc {
         SynthDef("PolyPerc", {
 			arg out, freq = 440, pw=pw, amp=amp, cutoff=cutoff, gain=gain, release=release;
-			var snd = LFPulse.ar(freq, 0, pw);
+			var snd = Pulse.ar(freq, pw);
 			var filt = MoogFF.ar(snd,cutoff,gain);
 			var env = Env.perc(level: amp, releaseTime: release).kr(2);
 			//			out.poll;


### PR DESCRIPTION
`LFPulse` ugen is a non-bandlimited, unipolar pulse generator intended for control signals. 

this replaces it with `Pulse` ugen, which is bandlimited and bipolar, eliminating DC offset problem.