### PR TITLE
fix voice control

### DIFF
--- a/scripts/tehn/earthsea.lua
+++ b/scripts/tehn/earthsea.lua
@@ -186,10 +186,12 @@ function grid_note(e)
       nvoices = nvoices + 1
     end
   else
-    engine.stop(e.id)
-    stop_screen_note(note)
-    lit[e.id] = nil
-    nvoices = nvoices - 1
+    if lit[e.id] ~= nil then
+      engine.stop(e.id)
+      stop_screen_note(note)
+      lit[e.id] = nil
+      nvoices = nvoices - 1
+    end
   end 
   gridredraw()
 end


### PR DESCRIPTION
when all 6 voices are allocated it's possible to sneak more in with repeated presses since the `nvoices` count gets decremented even if no voice was actually on for that `id`.  this tries to address that...

/cc @tehn 