### PR TITLE
earthsea: fix midi_event handling

### DIFF
--- a/scripts/tehn/earthsea.lua
+++ b/scripts/tehn/earthsea.lua
@@ -2,7 +2,7 @@
 --
 -- subtractive polysynth
 -- controlled by midi or grid
--- 
+--
 -- grid pattern player:
 -- 1 1 record toggle
 -- 1 2 play toggle
@@ -55,7 +55,7 @@ function init()
 
   params:add_control("cut", controlspec.new(0,32,"lin",0,8,""))
   params:set_action("cut", function(x) engine.cut(x) end)
-  
+
   params:add_control("fgain", controlspec.new(0,6,"lin",0,0,""))
   params:set_action("fgain", function(x) engine.fgain(x) end)
 
@@ -99,14 +99,14 @@ function init()
   params:bang()
 
   if g then gridredraw() end
-  
+
   screen_refresh_metro = metro.alloc()
   screen_refresh_metro.callback = function(stage)
     update()
     redraw()
   end
   screen_refresh_metro:start(1 / screen_framerate)
-  
+
   local startup_ani_count = 1
   local startup_ani_metro = metro.alloc()
   startup_ani_metro.callback = function(stage)
@@ -115,7 +115,7 @@ function init()
     startup_ani_count = startup_ani_count + 1
   end
   startup_ani_metro:start( 0.1, 3 )
-  
+
 end
 
 function gridkey(x, y, z)
@@ -124,7 +124,7 @@ function gridkey(x, y, z)
       if y == 1 and pat.rec == 0 then
         mode_transpose = 0
         trans.x = 5
-        trans.y = 5 
+        trans.y = 5
         pat:stop()
         engine.stopAll()
         stop_all_screen_notes()
@@ -159,13 +159,13 @@ function gridkey(x, y, z)
       local e = {}
       e.id = x*8 + y
       e.x = x
-      e.y = y 
-      e.state = z 
+      e.y = y
+      e.state = z
       pat:watch(e)
       grid_note(e)
     else
       trans.x = x
-      trans.y = y 
+      trans.y = y
     end
   end
   gridredraw()
@@ -192,7 +192,7 @@ function grid_note(e)
       lit[e.id] = nil
       nvoices = nvoices - 1
     end
-  end 
+  end
   gridredraw()
 end
 
@@ -214,7 +214,7 @@ function grid_note_trans(e)
     stop_screen_note(note)
     lit[e.id] = nil
     nvoices = nvoices - 1
-  end 
+  end
   gridredraw()
 end
 
@@ -222,7 +222,7 @@ function gridredraw()
   g:all(0)
   g:led(1,1,2 + pat.rec * 10)
   g:led(1,2,2 + pat.play * 10)
-  g:led(1,8,2 + mode_transpose * 10) 
+  g:led(1,8,2 + mode_transpose * 10)
 
   if mode_transpose == 1 then g:led(trans.x, trans.y, 4) end
   for i,e in pairs(lit) do
@@ -245,7 +245,7 @@ end
 
 function start_screen_note(note)
   local screen_note = nil
-  
+
   -- Get an existing screen_note if it exists
   local count = 0
   for key, val in pairs(screen_notes) do
@@ -256,16 +256,16 @@ function start_screen_note(note)
     count = count + 1
     if count > 8 then return end
   end
-  
+
   if screen_note then
     screen_note.active = true
   else
     screen_note = {note = note, active = true, repeat_timer = 0, x = math.random(128), y = math.random(64), init_radius = math.random(6,18), ripples = {} }
     table.insert(screen_notes, screen_note)
   end
-  
+
   add_ripple(screen_note)
-  
+
 end
 
 function stop_screen_note(note)
@@ -292,7 +292,7 @@ end
 
 function update()
   for n_key, n_val in pairs(screen_notes) do
-    
+
     if n_val.active then
       n_val.repeat_timer = n_val.repeat_timer + ripple_repeat_rate
       if n_val.repeat_timer >= 1 then
@@ -300,19 +300,19 @@ function update()
         n_val.repeat_timer = 0
       end
     end
-    
+
     local r_count = 0
     for r_key, r_val in pairs(n_val.ripples) do
       r_val.radius = r_val.radius + ripple_growth_rate
       r_val.life = r_val.life - ripple_decay_rate
-      
+
       if r_val.life <= 0 then
         n_val.ripples[r_key] = nil
       else
         r_count = r_count + 1
       end
     end
-    
+
     if r_count == 0 and not n_val.active then
       screen_notes[n_key] = nil
     end
@@ -323,7 +323,7 @@ function redraw()
   screen.clear()
   screen.aa(0)
   screen.line_width(1)
-  
+
   local first_ripple = true
   for n_key, n_val in pairs(screen_notes) do
     for r_key, r_val in pairs(n_val.ripples) do
@@ -336,7 +336,7 @@ function redraw()
       screen.stroke()
     end
   end
-  
+
   screen.update()
 end
 
@@ -360,9 +360,9 @@ local function midi_event(data)
     note_on(data[2], data[3])
   elseif data[1] == 128 then
     note_off(data[2])
-  elseif status == 176 then
+  elseif data[1] == 176 then
     --cc(data1, data2)
-  elseif status == 224 then
+  elseif data[1] == 224 then
     --bend(data1, data2)
   end
 end


### PR DESCRIPTION
for CC and pitchbend

When looking why MIDI wasn't working correctly I ran into these two lines. I expect they are remnants from when MIDI handling was done inside the scripts themselves.

Also a whole bunch of free whitespace fixes, @tehn I think your editor is broken/needs some config changes.