### PR TITLE
add midi clock out to playfair

### DIFF
--- a/scripts/tehn/playfair.lua
+++ b/scripts/tehn/playfair.lua
@@ -55,7 +55,7 @@ function init()
   screen.line_width(1)
   params:add_number("bpm",1,480,160)
   params:set_action("bpm", function(x)
-    t.time = 60/(24/3)/x
+    t.time = 60/24/x
   end)
 
   for channel=1,4 do
@@ -66,13 +66,11 @@ function init()
 
   t = metro.alloc()
   t.count = -1
-  t.time = 60/(24/3)/params:get("bpm")
+  t.time = 60/24/params:get("bpm")
   t.callback = function()
     if midi_device then midi.send(midi_device, {248}) end
-    if midi_device then midi.send(midi_device, {248}) end
-    if midi_device then midi.send(midi_device, {248}) end
 
-    if midiclocktimerticks % 2 == 0 then
+    if midiclocktimerticks == 0 then
       if reset then
         for i=1,4 do track[i].pos = 1 end
         reset = false
@@ -83,7 +81,7 @@ function init()
       redraw()
     end
 
-    if midiclocktimerticks > 2 then
+    if midiclocktimerticks == 5 then
       midiclocktimerticks = 0
     else
       midiclocktimerticks = midiclocktimerticks + 1

--- a/scripts/tehn/playfair.lua
+++ b/scripts/tehn/playfair.lua
@@ -150,3 +150,8 @@ midi.remove = function(dev)
   print('playfair: midi device removed', dev.id, dev.name)
   midi_device = nil
 end
+function cleanup()
+  midi_device = nil
+  midi.add = nil
+  midi.remove = nil
+end

--- a/scripts/tehn/playfair.lua
+++ b/scripts/tehn/playfair.lua
@@ -151,7 +151,6 @@ midi.remove = function(dev)
   midi_device = nil
 end
 function cleanup()
-  midi_device = nil
   midi.add = nil
   midi.remove = nil
 end


### PR DESCRIPTION
this is a work-in-progress. i could use some advice!

i think it will need params for clock on/off and a param to select if midi clock start is sent when playfair resets.

i tried running a faster metro (one callback every 1/24th of a quarter note) but it was not accurate. so i batch 3 midi clocks in each callback instead. this works, but i have only tested it on one device.

once this is done, maybe a re-usable class could be extracted for re-use in the other scripts.