### PR TITLE
optional midi sync: playfair

### DIFF
--- a/scripts/tehn/playfair.lua
+++ b/scripts/tehn/playfair.lua
@@ -53,6 +53,7 @@ function init()
   for i=1,4 do reer(i) end
 
   screen.line_width(1)
+  params:add_option("midi_sync",{"off","on"})
   params:add_number("bpm",1,480,160)
   params:set_action("bpm", function(x)
     t.time = 60/24/x
@@ -69,7 +70,7 @@ function init()
   t.count = -1
   t.time = 60/24/params:get("bpm")
   t.callback = function()
-    if midi_device then midi.send(midi_device, {248}) end
+    if midi_device and params:get("midi_sync")==2 then midi.send(midi_device, {248}) end
 
     if midiclocktimerticks == 0 then
       if reset then
@@ -149,6 +150,7 @@ midi.remove = function(dev)
   print('playfair: midi device removed', dev.id, dev.name)
   midi_device = nil
 end
+
 function cleanup()
   midi.add = nil
   midi.remove = nil


### PR DESCRIPTION
@audionerd 

added a simple param to enable/disable clock sync.

found that one of my midi controllers freaked out when having clock sent to it.

but generally it'd be great to eventually build out a library that has port selection for which midi device would be sending sync-- we've been thinking about a good solution... hopefully on the way soon.