### PR TITLE
clock fixes

### DIFF
--- a/lib/lua/beatclock.lua
+++ b/lib/lua/beatclock.lua
@@ -128,8 +128,10 @@ end
 
 function BeatClock:enable_midi()
   self.midi = true  
- 
-  norns.midi.event = function (id, data)
+end
+
+function BeatClock:process_midi(data)
+  if self.midi then
     status = data[1]
     data1 = data[2]
     data2 = data[3]
@@ -145,7 +147,7 @@ function BeatClock:enable_midi()
       elseif status == 252 then -- midi clock stop
         self:stop(id)
       end
-    end
+    end 
   end
 end
 

--- a/scripts/tehn/awake.lua
+++ b/scripts/tehn/awake.lua
@@ -66,6 +66,7 @@ end
 function init()
   print("grid/seek")
 
+  params:add_option("midi_sync",{"off","on"})
   params:add_number("tempo",20,240,48)
   params:set_action("tempo", function(n) 
     t.time = 60/24/n
@@ -112,7 +113,7 @@ function init()
   t.time = 60/24/params:get("tempo")
 
   t.callback = function(stage)
-    if midi_device then midi.send(midi_device, {248}) end
+    if midi_device and params:get("midi_sync")==2 then midi.send(midi_device, {248}) end
 
     if midiclocktimerticks == 0 then
       one.pos = one.pos + 1

--- a/scripts/tehn/playfair.lua
+++ b/scripts/tehn/playfair.lua
@@ -69,7 +69,6 @@ function init()
   params:bang()
   
   clk:start()
-  
 end
 
 function reset_pattern()
@@ -140,6 +139,10 @@ function redraw()
     end
   end
   screen.update()
+end
+
+midi.add = function(dev)
+  dev.event = clk.process_midi
 end
 
 


### PR DESCRIPTION
@Dewb we can't overwrite `norns.midi.event` with any other code or it breaks other scripts. i believe my fix here is the right approach-- see playfair example

also added clock option to `awake`

we have two clock approaches in the codebase now-- it'd be good to conform to BeatClock as it's more elegant and maintainable

would love any input re: midi management: https://github.com/monome/norns/issues/454