### PR TITLE
fix er, playfair, foulplay

### DIFF
--- a/data/jah/step.pset
+++ b/data/jah/step.pset
@@ -1,7 +1,8 @@
+"pattern": 1
 "last_row_cuts": 2
 "cut_quant": 1
 "beats_per_pattern": 4
-"tempo": 160.0
+"tempo": 112.4
 "swing_amount": 0
 "1_sample": /home/we/dust/audio/common/606/606-BD.wav
 "1_start_pos": 0
@@ -19,6 +20,8 @@
 "1_filter_env_atk": 0.001
 "1_filter_env_rel": 0.25
 "1_filter_env_mod": 0.0
+"1_dist": 0
+"1_in_mutegroup": 1
 "1_delay_send": -43.876400520322
 "1_reverb_send": -inf
 "2_sample": /home/we/dust/audio/common/606/606-SD.wav
@@ -37,6 +40,8 @@
 "2_filter_env_atk": 0.001
 "2_filter_env_rel": 0.25
 "2_filter_env_mod": 0.0
+"2_dist": 0
+"2_in_mutegroup": 1
 "2_delay_send": -inf
 "2_reverb_send": -6.0
 "3_sample": /home/we/dust/audio/common/606/606-CH.wav
@@ -55,6 +60,8 @@
 "3_filter_env_atk": 0.001
 "3_filter_env_rel": 0.25
 "3_filter_env_mod": 0.0
+"3_dist": 0
+"3_in_mutegroup": 1
 "3_delay_send": -inf
 "3_reverb_send": -inf
 "4_sample": /home/we/dust/audio/common/606/606-OH.wav
@@ -73,6 +80,8 @@
 "4_filter_env_atk": 0.001
 "4_filter_env_rel": 0.25
 "4_filter_env_mod": 0.0
+"4_dist": 0
+"4_in_mutegroup": 1
 "4_delay_send": -inf
 "4_reverb_send": -inf
 "5_sample": /home/we/dust/audio/common/606/606-LT.wav
@@ -91,6 +100,8 @@
 "5_filter_env_atk": 0.001
 "5_filter_env_rel": 0.25
 "5_filter_env_mod": 0.0
+"5_dist": 0
+"5_in_mutegroup": 1
 "5_delay_send": -28.608246736829
 "5_reverb_send": -inf
 "6_sample": /home/we/dust/audio/common/606/606-HT.wav
@@ -109,6 +120,8 @@
 "6_filter_env_atk": 0.06
 "6_filter_env_rel": 0.91
 "6_filter_env_mod": 0.0
+"6_dist": 0
+"6_in_mutegroup": 1
 "6_delay_send": -33.0
 "6_reverb_send": -inf
 "7_sample": /home/we/dust/audio/common/606/606-CY.wav
@@ -127,6 +140,8 @@
 "7_filter_env_atk": 0.001
 "7_filter_env_rel": 0.25
 "7_filter_env_mod": 0.0
+"7_dist": 0
+"7_in_mutegroup": 1
 "7_delay_send": -inf
 "7_reverb_send": -inf
 "8_sample": -
@@ -145,11 +160,13 @@
 "8_filter_env_atk": 0.001
 "8_filter_env_rel": 0.25
 "8_filter_env_mod": 0.0
+"8_dist": 0
+"8_in_mutegroup": 1
 "8_delay_send": -inf
 "8_reverb_send": -inf
 "delay_time": 0.37257799675309
 "delay_feedback": 0.625
 "delay_level": -10.0
-"reverb_room size": 0.5
+"reverb_room_size": 0.5
 "reverb_damp": 0.65
 "reverb_level": -10.0

--- a/lib/lua/er.lua
+++ b/lib/lua/er.lua
@@ -1,9 +1,8 @@
-
-
+er = {}
 -- Euclidean rhythm (http://en.wikipedia.org/wiki/Euclidean_Rhythm)
 -- @param k : number of pulses
 -- @param n : total number of steps
-function er(k, n)
+function er.gen(k, n)
    -- results array, intially all zero
    local r = {}
    for i=1,n do r[i] = false end
@@ -16,8 +15,10 @@ function er(k, n)
       if b >= n then
 	 b = b - n
 	 r[i] = true
-      end      
+      end
       b = b + k
-   end   
-   return r   
+   end
+   return r
 end
+
+return er

--- a/scripts/justmat/foulplay.lua
+++ b/scripts/justmat/foulplay.lua
@@ -94,7 +94,7 @@
 -- release the copy button.
 --
 
-require 'er'
+er = require 'er'
 
 engine.name = 'Ack'
 
@@ -118,7 +118,7 @@ local current_pset = 0
 
 -- a table of midi note on/off status i = 1/0
 local note_off_queue = {}
-for i = 1, 8 do 
+for i = 1, 8 do
   note_off_queue[i] = 0
 end
 
@@ -189,7 +189,7 @@ local function reer(i)
   if gettrack(current_mem_cell,i).k == 0 then
     for n=1,32 do gettrack(current_mem_cell,i).s[n] = false end
   else
-    gettrack(current_mem_cell,i).s = rotate_pattern(er(gettrack(current_mem_cell,i).k, gettrack(current_mem_cell,i).n), gettrack(current_mem_cell, i).rotation)
+    gettrack(current_mem_cell,i).s = rotate_pattern(er.gen(gettrack(current_mem_cell,i).k, gettrack(current_mem_cell,i).n), gettrack(current_mem_cell, i).rotation)
   end
 end
 
@@ -207,14 +207,14 @@ local function trig()
           note_off_queue[i] = 1
         end
       end
-    else 
+    else
       if note_off_queue[i] == 1 then
-        m.note_off(params:get(i.."midi_note"), 100, params:get(i.."midi_chan")) 
+        m.note_off(params:get(i.."midi_note"), 100, params:get(i.."midi_chan"))
         note_off_queue[i] = 0
       end
     end
     -- logical and
-    if t.trig_logic == 1 then 
+    if t.trig_logic == 1 then
       if t.s[t.pos] and gettrack(current_mem_cell,t.logic_target).s[gettrack(current_mem_cell,t.logic_target).pos]  then
         if math.random(100) <= t.prob and t.mute == 0 then
           if params:get(i.."send_midi") == 1 then
@@ -224,13 +224,13 @@ local function trig()
             note_off_queue[i] = 1
           end
         else break end
-      else 
+      else
         if note_off_queue[i] == 1 then
           m.note_off(params:get(i.."midi_note"), 100, params:get(i.."midi_chan"))
           note_off_queue[i] = 0
         end
       end
-    -- logical or  
+    -- logical or
     elseif t.trig_logic == 2 then
       if t.s[t.pos] or gettrack(current_mem_cell,t.logic_target).s[gettrack(current_mem_cell,t.logic_target).pos] then
         if math.random(100) <= t.prob and t.mute == 0 then
@@ -241,13 +241,13 @@ local function trig()
             note_off_queue[i] = 1
           end
         else break end
-      else 
+      else
         if note_off_queue[i] == 1 then
           m.note_off(params:get(i.."midi_note"), 100, params:get(i.."midi_chan"))
           note_off_queue[i] = 0
         end
       end
-    -- logical nand  
+    -- logical nand
     elseif t.trig_logic == 3 then
       if t.s[t.pos] and gettrack(current_mem_cell,t.logic_target).s[gettrack(current_mem_cell,t.logic_target).pos]  then
       elseif t.s[t.pos] then
@@ -259,13 +259,13 @@ local function trig()
             note_off_queue[i] = 1
           end
         else break end
-      else 
+      else
         if note_off_queue[i] == 1 then
           m.note_off(params:get(i.."midi_note"), 100, params:get(i.."midi_chan"))
           note_off_queue[i] = 0
         end
       end
-    -- logical nor  
+    -- logical nor
     elseif t.trig_logic == 4 then
       if not t.s[t.pos] then
         if not gettrack(current_mem_cell,t.logic_target).s[gettrack(current_mem_cell,t.logic_target).pos] and t.mute == 0 then
@@ -276,13 +276,13 @@ local function trig()
             note_off_queue[i] = 1
           end
         else break end
-      else 
+      else
         if note_off_queue[i] == 1 then
           m.note_off(params:get(i.."midi_note"), 100, params:get(i.."midi_chan"))
           note_off_queue[i] = 0
         end
       end
-    -- logical xor   
+    -- logical xor
     elseif t.trig_logic == 5 then
       if t.mute == 0 then
         if not t.s[t.pos] and not gettrack(current_mem_cell,t.logic_target).s[gettrack(current_mem_cell,t.logic_target).pos] then
@@ -313,7 +313,7 @@ function init()
   clk.on_step = step
   clk.on_select_internal = function() clk:start() end
   clk.on_select_external = reset_pattern
-  
+
   -- add params
   clk:add_clock_params()
   params:add_separator()
@@ -323,7 +323,7 @@ function init()
     params:add_number(i.."midi_note", i..": midi note", 0, 127, 0)
     ack.add_channel_params(i)
     params:add_separator()
-  end  
+  end
   ack.add_effects_params()
   -- load default pset
   params:read("justmat/foulplay.pset")
@@ -336,7 +336,7 @@ function init()
   else
     clk:start()
   end
-  
+
   -- grid refresh timer, 15 fps
   metro_grid_redraw = metro.alloc(function(stage) grid_redraw() end, 1 / 15)
   metro_grid_redraw:start()
@@ -361,7 +361,7 @@ function step()
   else
     for i=1,8 do
       gettrack(current_mem_cell,i).pos = (gettrack(current_mem_cell,i).pos % gettrack(current_mem_cell,i).n) + 1
-    end 
+    end
   end
   trig()
   redraw()
@@ -374,8 +374,8 @@ function key(n,z)
   if n==3 and z==1 and view==1 then
     if params:get(track_edit.."send_midi") == 1 then
       page = (page + 1) % 4
-    -- there are only 2 pages of midi options  
-    else page = (page + 1) % 2 end 
+    -- there are only 2 pages of midi options
+    else page = (page + 1) % 2 end
   end
   if n==3 then alt = z end
   -- track selection in track edit view
@@ -430,21 +430,21 @@ function enc(n,d)
     if params:get(track_edit.."send_midi") == 1 then
     -- per track volume control
       if n==1 then
-        params:delta(track_edit .. ": vol", d)
+        params:delta(track_edit .. "_vol", d)
       elseif n==2 then
-        params:delta(track_edit .. ": vol env atk", d)
+        params:delta(track_edit .. "_vol_env_atk", d)
       elseif n==3 then
-        params:delta(track_edit .. ": vol env rel", d)
+        params:delta(track_edit .. "_vol_env_rel", d)
       end
-    -- if send midi is on  
+    -- if send midi is on
     else
       -- encoder 1 sets midi channel, 2 selects a note to send
       if n==1 then
-        params:delta(track_edit .. ": midi chan", d)
+        params:delta(track_edit .. "_midi_chan", d)
       elseif n==2 then
-        params:delta(track_edit .. ": midi note", d)
+        params:delta(track_edit .. "_midi_note", d)
       end
-    end  
+    end
 
   elseif view==1 and page==1 then
     -- trigger logic and probability settings
@@ -459,21 +459,21 @@ function enc(n,d)
   elseif view==1 and page==2 then
     -- sample playback settings
     if n==1 then
-      params:delta(track_edit .. ": speed", d)
+      params:delta(track_edit .. "_speed", d)
     elseif n==2 then
-      params:delta(track_edit .. ": start pos", d)
+      params:delta(track_edit .. "_start_pos", d)
     elseif n==3 then
-      params:delta(track_edit .. ": end pos", d)
+      params:delta(track_edit .. "_end_pos", d)
     end
 
   elseif view==1 and page==3 then
     -- filter and fx sends
     if n==1 then
-      params:delta(track_edit .. ": filter cutoff", d)
+      params:delta(track_edit .. "_filter_cutoff", d)
     elseif n==2 then
-      params:delta(track_edit .. ": delay send", d)
+      params:delta(track_edit .. "_delay_send", d)
     elseif n==3 then
-      params:delta(track_edit .. ": reverb send", d)
+      params:delta(track_edit .. "_reverb_send", d)
     end
   -- HOME
   -- choose focused track, track fill, and track length
@@ -559,11 +559,11 @@ function redraw()
       screen.line(121, 15)
       screen.move(64, 25)
       screen.level(4)
-      screen.text_center("1. vol : " .. string.format("%.1f", params:get(track_edit .. ": vol")))
+      screen.text_center("1. vol : " .. string.format("%.1f", params:get(track_edit .. "_vol")))
       screen.move(64, 35)
-      screen.text_center("2. envelope attack : " .. params:get(track_edit .. ": vol env atk"))
+      screen.text_center("2. envelope attack : " .. params:get(track_edit .. "_vol_env_atk"))
       screen.move(64, 45)
-      screen.text_center("3. envelope release : " .. params:get(track_edit .. ": vol env rel"))
+      screen.text_center("3. envelope release : " .. params:get(track_edit .. "_vol_env_rel"))
     else
       screen.move(5, 10)
       screen.level(15)
@@ -574,11 +574,11 @@ function redraw()
       screen.line(121, 15)
       screen.move(64, 25)
       screen.level(4)
-      screen.text_center("1. midi channel : " .. params:get(track_edit .. ": midi chan"))
+      screen.text_center("1. midi channel : " .. params:get(track_edit .. "_midi_chan"))
       screen.move(64, 35)
-      screen.text_center("2. midi note : " .. params:get(track_edit .. ": midi note"))
+      screen.text_center("2. midi note : " .. params:get(track_edit .. "_midi_note"))
     end
-    
+
   elseif view==1 and page==1 then
     screen.move(5, 10)
     screen.level(15)
@@ -629,11 +629,11 @@ function redraw()
     screen.line(121, 15)
     screen.move(64, 25)
     screen.level(4)
-    screen.text_center("1. speed : " .. params:get(track_edit .. ": speed"))
+    screen.text_center("1. speed : " .. params:get(track_edit .. "_speed"))
     screen.move(64, 35)
-    screen.text_center("2. start pos : " .. params:get(track_edit .. ": start pos"))
+    screen.text_center("2. start pos : " .. params:get(track_edit .. "_start_pos"))
     screen.move(64, 45)
-    screen.text_center("3. end pos : " .. params:get(track_edit .. ": end pos"))
+    screen.text_center("3. end pos : " .. params:get(track_edit .. "_end_pos"))
 
   elseif view==1 and page==3 then
     screen.move(5, 10)
@@ -645,11 +645,11 @@ function redraw()
     screen.line(121, 15)
     screen.level(4)
     screen.move(64, 25)
-    screen.text_center("1. filter cutoff : " .. math.floor(params:get(track_edit .. ": filter cutoff") + 0.5))
+    screen.text_center("1. filter cutoff : " .. math.floor(params:get(track_edit .. "_filter_cutoff") + 0.5))
     screen.move(64, 35)
-    screen.text_center("2. delay send : " .. params:get(track_edit .. ": delay send"))
+    screen.text_center("2. delay send : " .. params:get(track_edit .. "_delay_send"))
     screen.move(64, 45)
-    screen.text_center("3. reverb send : " .. params:get(track_edit .. ": reverb send"))
+    screen.text_center("3. reverb send : " .. params:get(track_edit .. "_reverb_send"))
   end
   screen.stroke()
   screen.update()
@@ -863,7 +863,7 @@ function loadstate()
           memory_cell[j][i].mute = tonumber(io.read())
         end
       end
-    else 
+    else
       print("invalid data file")
     end
     io.close(file)

--- a/scripts/tehn/halfsecond.lua
+++ b/scripts/tehn/halfsecond.lua
@@ -1,7 +1,7 @@
 -- softcut test
 -- half sec loop 75% decay
 --
--- ENC1 to toggle HOLD
+-- KEY3 to toggle HOLD
 
 engine.name = 'SoftCut'
 

--- a/scripts/tehn/playfair.lua
+++ b/scripts/tehn/playfair.lua
@@ -9,7 +9,7 @@
 -- key1 = ALT
 -- ALT-enc1 = bpm
 
-require 'er'
+er = require 'er'
 
 engine.name = 'Ack'
 
@@ -56,7 +56,7 @@ local function reer(i)
   if track[i].k == 0 then
     for n=1,32 do track[i].s[n] = false end
   else
-    track[i].s = er(track[i].k,track[i].n)
+    track[i].s = er.gen(track[i].k,track[i].n)
   end
 end
 


### PR DESCRIPTION
`er` lib was sloppy (just an include, not a returned table) hence it was getting cleared out by the new globals reset. and then `require` wouldn't bring it back.

lots of fixes in foulplay for param syntax change, whitespace fixes

@notjustmat 