### PR TITLE
Minor fixes to Mark Eats demo scripts

### DIFF
--- a/scripts/mark_eats/graph_demo.lua
+++ b/scripts/mark_eats/graph_demo.lua
@@ -39,11 +39,10 @@ local screen_refresh_metro
 local screen_dirty = true
 local shift_key = false
 
-engine.name = "TestSine"
-
 
 function init()
-  engine.amp(0)
+  
+  screen.aa(1)
   
   -- Dummy data for graphs
   for i = 1, 12 do point_vals[i] = math.random() * 2 - 1 end
@@ -53,7 +52,7 @@ function init()
   
   -- Metro to call redraw()
   screen_refresh_metro = metro.alloc()
-  screen_refresh_metro.callback = function(stage)
+  screen_refresh_metro.callback = function()
     if screen_dirty then
       screen_dirty = false
       redraw()
@@ -63,7 +62,7 @@ function init()
   
   -- Metro for sequencer demo
   step_metro = metro.alloc()
-  step_metro.callback = function(stage)
+  step_metro.callback = function()
     if graph_id == 4 then
       step = step % 16 + 1
       screen_dirty = true
@@ -248,7 +247,6 @@ end
 -- Drawing
 function redraw()
   screen.clear()
-  screen.aa(1)
   
   -- Don't panic! Only one line of this redraw function is used to draw the graph, everything else relates to the supporting text and graphics.
   

--- a/scripts/mark_eats/scales_demo.lua
+++ b/scripts/mark_eats/scales_demo.lua
@@ -34,15 +34,13 @@ local function init_scale()
 end
 
 local function advance_step()
-  if step > scale_len then
+  if step >= scale_len then
     step = scale_len
     step_increment = -1
-  else
-    step = step + step_increment
-    if step == 1 or step == scale_len then
-      step_increment = step_increment * -1
-    end
+  elseif step == 1 then
+    step_increment = 1
   end
+  step = step + step_increment
   engine.hz(MusicUtil.note_num_to_freq(scale_notes[step]))
   redraw()
 end
@@ -67,6 +65,7 @@ function init()
   step_metro.callback = advance_step
   start_stop_metro()
   
+  screen.aa(1)
   redraw()
 end
 
@@ -117,7 +116,6 @@ end
 
 function redraw()
   screen.clear()
-  screen.aa(1)
 
   screen.level(15)
   


### PR DESCRIPTION
Removes dummy engine from graph_demo as per https://github.com/monome/norns/pull/614
Fixes a bug in scales_demo.
Other minor tidying.