### PR TITLE
Awake midi and 256 updates

### DIFF
--- a/data/tehn/awake.pset
+++ b/data/tehn/awake.pset
@@ -1,6 +1,6 @@
 "tempo": 46
-"scale mode": 3
-"trans": 0
+"scale_mode": 2
+"root_note": 45
 "amp": 0.5
 "pw": 50.0
 "release": 1.2

--- a/lib/lua/beatclock.lua
+++ b/lib/lua/beatclock.lua
@@ -23,6 +23,8 @@ function BeatClock.new(name)
   i:bpm_change(110)
 
   i.on_step = function(e) print("BeatClock executing step") end
+  i.on_start = function(e) end
+  i.on_stop = function(e) end
   i.on_select_internal = function(e) print("BeatClock using internal clock") end
   i.on_select_external = function(e) print("BeatClock using external clock") end
   
@@ -44,6 +46,7 @@ function BeatClock:start(dev_id)
       end
     end
   end
+  self.on_start()
 end
 
 function BeatClock:stop(dev_id)
@@ -56,6 +59,7 @@ function BeatClock:stop(dev_id)
       end
     end
   end
+  self.on_stop()
 end
 
 function BeatClock:advance_step()


### PR DESCRIPTION
Several additions/changes to awake:
- MIDI out
- Switched to using musicutil for defining scale (removed 'transpose' and replaced with 'root note', let me know if this isn't desired)
- Simple 256 support (displays both views at once)
- Play/pause
- Param for step length
- Param for note length (only applies to MIDI notes so far as polyperc doesn't have a note off)
- added some extra callbacks for beatclock that were required