### PR TITLE
zellen: add loop mode + velocity variance

### DIFF
--- a/docs/sbaio/zellen/index.md
+++ b/docs/sbaio/zellen/index.md
@@ -30,13 +30,13 @@ Set the play direction with ENC3.
 * drunken down: Like down, but decides for each step randomly if it goes up or down.
 
 ### Sequencing modes
-Set the sequencing mode in the parameters screen. Default is semi-manual.
+Set the sequencing mode in the parameters screen. Default is semi-automatic.
 * manual: Press KEY2 to play the next step in the sequence for a single generation.
-* semi-manual: Plays the sequence for a single generation.
+* semi-automatic: Plays the sequence for a single generation (and loops it if "loop seq in semi-auto mode" is enabled (default)).
 * automatic: Like semi-automatic, but automatically calculates the next generation and plays it.
 
 ## MIDI
-Set the MIDI device number (default: 1) and MIDI velocity (default: 100) in the parameters screen. MIDI sync and more MIDI related features will be implemented in a future update.
+Set the MIDI channel (default: 1), MIDI device number (default: 1) and MIDI velocity (default: 100) in the parameters screen. MIDI sync and more MIDI related features will be implemented in a future update.
 
 ## More Parameters
 There is lots more to discover in the parameters screen, like root note, scale, and ghost offset.

--- a/scripts/sbaio/zellen.lua
+++ b/scripts/sbaio/zellen.lua
@@ -9,7 +9,7 @@
 -- KEY3: advance generation
 -- hold KEY1 + press KEY3:
 --   delete board
--- hold KEY2 + press KEY3:
+-- hold KEY1 + press KEY2:
 --   save parameters
 --
 -- ENC1: set speed (bpm)
@@ -355,9 +355,11 @@ local function reset_sequence()
     beat_step = 1
   end
   
-  if(seq_mode == 3) then
-    init_position()
-    generation_step()
+  if(seq_mode == 3 or (seq_mode == 2 and params:get("loop_semi_auto_seq") == 1)) then
+    if(seq_mode == 3) then
+      init_position()
+      generation_step()
+    end
     if(not seq_running) then
       seq_counter:start()
       seq_running = true
@@ -505,6 +507,7 @@ function init()
   
   -- params
   params:add_option("seq_mode", "seq mode", SEQ_MODES, 2)
+  params:add_option("loop_semi_auto_seq", "loop seq in semi-auto mode", {"Y", "N"}, 1)
   
   params:add_option("scale", "scale", SCALE_NAMES, 1)
   params:set_action("scale", set_scale)
@@ -673,9 +676,11 @@ function key(n, z)
     if(KEY3_DOWN and KEY1_DOWN) then
       clear_board()
     elseif(KEY3_DOWN) then
-      seq_counter:stop()
-      seq_running = false
-      show_playing_indicator = false
+      if(not (seq_mode == 2 and params:get("loop_semi_auto_seq") == 1)) then
+        seq_counter:stop()
+        seq_running = false
+        show_playing_indicator = false
+      end
       generation_step()
     end
   end

--- a/scripts/sbaio/zellen.lua
+++ b/scripts/sbaio/zellen.lua
@@ -381,7 +381,7 @@ local function play_seq_step()
   
   local beat_seq_lengths = #beats
   
-  if (beats[(beat_step % beat_seq_lengths) + 1]) then
+  if (beats[(beat_step % beat_seq_lengths) + 1] or seq_mode == 1) then
     if (play_pos <= #playable_cells) then
       position = playable_cells[play_pos]
       local midi_note = scale[(position.x - 1) + position.y]


### PR DESCRIPTION
two new features for the zellen sequencer:
* loop mode: loops the sequence for the current generation in semi-automatic mode
* velocity variance: a velocity variance value can be set in parameters which defines a range for the velocity (velocity +/- variance). within this range the velocity for each step will be determined randomly.
* some small tweaks